### PR TITLE
Fix DualDialogue lines being ignored by PDF line count

### DIFF
--- a/pdf/pdf.go
+++ b/pdf/pdf.go
@@ -224,6 +224,7 @@ func buildPDF(script *ast.Script) (*gopdf.GoPdf, error) {
 
 					// Add the line. (styleLine() as we do not want to track it yet)
 					styleLine(line)
+					leftLines += 1
 
 					leftY = thisPDF.GetY()
 
@@ -241,6 +242,7 @@ func buildPDF(script *ast.Script) (*gopdf.GoPdf, error) {
 
 					// Add the line. (styleLine() as we do not want to track it yet)
 					styleLine(line)
+					rightLines += 1
 
 					rightY = thisPDF.GetY()
 				}


### PR DESCRIPTION
### Description of the change
With DualDialogue the lines were ignored by the overall line count in the PDF compiler. I believe this came from an oversight where the number of left and right lines that were written in DualDialogue were not being kept track of. I have attempted to remedy this with a simple +1 to the appropriate left or right line counts whenever a line is added with styleLine.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits
The bottom margin on pages with DualDialogue should now maintain their proper 1-inch margin.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
I am not sure if line.leading() should also be added to this account, I have not studied the code base enough to know what that variable does.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable issues

<!-- Enter any applicable issues here -->